### PR TITLE
Fix path import

### DIFF
--- a/pyExamples/RCFrameEarthquake.py
+++ b/pyExamples/RCFrameEarthquake.py
@@ -31,7 +31,7 @@ loadConst('-time', 0.0)
 
 # Define nodal mass in terms of axial load on columns
 g = 386.4
-m = P/g
+m = RCFrameGravity.P/g
 
 mass(3, m, m, 0.0)
 mass(4, m, m, 0.0)

--- a/pyExamples/RCFrameEarthquake.py
+++ b/pyExamples/RCFrameEarthquake.py
@@ -19,7 +19,7 @@ wipe()
 # ----------------------------------------------------
 
 # Do operations of Example3.1 by sourcing in the tcl file
-exec(open('RCFrameGravity.py').read())
+import RCFrameGravity
 print("Gravity Analysis Completed")
 
 # Set the gravity loads to be constant & reset the time in the domain

--- a/pyExamples/RCFramePushOver.py
+++ b/pyExamples/RCFramePushOver.py
@@ -16,7 +16,7 @@ wipe()
 # ----------------------------------------------------
 
 # Do operations of Example3.1 by sourcing in the tcl file
-exec(open('RCFrameGravity.py').read())
+import RCFrameGravity
 print("Gravity Analysis Completed")
 
 # Set the gravity loads to be constant & reset the time in the domain

--- a/src/RCFrameEarthquake.rst
+++ b/src/RCFrameEarthquake.rst
@@ -9,7 +9,7 @@
 #. The file for gravity analysis is also needed :download:`here </pyExamples/RCFrameGravity.py>`.
 #. The ReadRecord is a useful python function for parsing the PEER strong motion data base files and returning the ``dt``, ``nPts`` and creating a file containing just data points. The function is kept in a seperate file  :download:`here </pyExamples/ReadRecord.py>` and is imported in the example.
 #. The ground motion data file :download:`here </pyExamples/elCentro.at2>` must be put in the same folder.
-#. Change the line 9 below to set the right path where the OpenSeesPy library located.
+#. Change the line 9 below to set the right path where the OpenSeesPy library located or set ``PYTHONPATH`` environment variable (see :ref:`linux-install-settings`).
 #. Run the source code in your favorate Python program and should see ``Passed!`` in the results and a plotting of displacement for node 3
 
 .. image:: /_static/RCFrameEarthquake.png

--- a/src/RCFramePushOver.rst
+++ b/src/RCFramePushOver.rst
@@ -7,7 +7,7 @@
 
 #. The source code is shown below, which can be downloaded :download:`here </pyExamples/RCFramePushOver.py>`.
 #. The file for gravity analysis is also needed ::download:`here </pyExamples/RCFrameGravity.py>`.
-#. Change the line 9 below to set the right path where the OpenSeesPy library located.
+#. Change the line 9 below to set the right path where the OpenSeesPy library located or set ``PYTHONPATH`` environment variable.
 #. Run the source code in your favorate Python program and should see ``Passed!`` in the results.
 
 .. literalinclude:: /pyExamples/RCFramePushOver.py

--- a/src/linux.rst
+++ b/src/linux.rst
@@ -1,5 +1,6 @@
 .. include:: sub.txt
 
+.. _linux-install-settings:
 
 =======================================
  OpenSeesPy |opspy_version| for Linux:
@@ -13,9 +14,19 @@
 
 
 Two files, ``opensees.so`` and ``LICENSE.rst``, are included in the zip file.
-Put the library file ``opensees.so`` in a directoy, which path should be copied
+Put the library file ``opensees.so`` in a directory, which path should be copied
 to
 
 ::
 
    sys.path.append('/path/to/OpenSeesPy')
+
+Alternatively, you can set ``PYTHONPATH`` environment variable in
+``.bash_profile`` or ``.bashrc``, for example:
+
+::
+
+   export PYTHONPATH="$PYTHONPATH:$HOME/OpenSeesPy"
+
+and then you can remove or comment the ``sys.path.append`` line from your
+Opensees files.


### PR DESCRIPTION
This PR:
1. uses simpler `import` instead of `exec/open/read` command as recommended in 
https://stackoverflow.com/questions/2349991/how-to-import-other-python-files
2. add info on setting PYTHONPATH env variable to avoid setting the path to OpenSeesPy directory for each example python file 
