### PR TITLE
Add missing nodeTag in nodeEigenvector documentation

### DIFF
--- a/src/nodeEigenvector.rst
+++ b/src/nodeEigenvector.rst
@@ -4,7 +4,7 @@
  nodeEigenvector command
 =========================
 
-.. function:: nodeEigenvector(eigenvector, dof=-1)
+.. function:: nodeEigenvector(nodeTag, eigenvector, dof=-1)
 
    Returns the eigenvector at a specified node.
 


### PR DESCRIPTION
As in the title, nodeTag is missing in the args of nodeEigenvector documentation. 