### PR TITLE
changing 'mass' to 'massDens'

### DIFF
--- a/src/elasticBeamColumn.rst
+++ b/src/elasticBeamColumn.rst
@@ -10,14 +10,14 @@ This command is used to construct an elasticBeamColumn element object. The argum
 
 
 
-.. function:: element('elasticBeamColumn', eleTag, *eleNodes, Area, E_mod, Iz, transfTag, ['-mass', mass],['-cMass'], ['-release', releaseCode])
+.. function:: element('elasticBeamColumn', eleTag, *eleNodes, Area, E_mod, Iz, transfTag, ['-mass', massDens],['-cMass'], ['-release', releaseCode])
 
    :noindex:
 
    For a two-dimensional problem
 
 
-.. function:: element('elasticBeamColumn', eleTag, *eleNodes, Area, E_mod, G_mod, Jxx, Iy, Iz, transfTag, ['-mass', mass], ['-cMass'])
+.. function:: element('elasticBeamColumn', eleTag, *eleNodes, Area, E_mod, G_mod, Jxx, Iy, Iz, transfTag, ['-mass', massDens], ['-cMass'])
 
    :noindex:
 


### PR DESCRIPTION
for the '-mass' parameter, 'massDens' has been introduced in the table as the value, but 'mass' is used in the function signature, which is inconsistent.