### PR TITLE
another trial to fix Read the Docs building process

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -22,7 +22,7 @@
 # sys.path.insert(0, os.path.abspath('.'))
 import os
 import sys
-sys.path.insert(0, os.path.abspath('./src/ops_vis/.'))
+sys.path.insert(0, os.path.abspath('./src/ops_vis'))
 
 import sphinx_rtd_theme
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openseespy
+numpy
+matplotlib

--- a/src/ops_vis/ops_vis.py
+++ b/src/ops_vis/ops_vis.py
@@ -12,8 +12,8 @@
 #    therefore right angles are not guaranteed to be 90 degrees on the
 #    plots
 
-# import openseespy.opensees as ops  # installed from pip
-import opensees as ops  # local compilation
+import openseespy.opensees as ops  # installed from pip
+# import opensees as ops  # local compilation
 import numpy as np
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D


### PR DESCRIPTION
This PR further tries to fix the Read the Docs building process.

It adds requirements.txt file which is used by the RTD paltform, but you have to add the path './requirements.txt' to Advanced Settings in the RTD OpenSeesPyDoc project admin dashboard:
https://docs.readthedocs.io/en/stable/guides/specifying-dependencies.html