### PR TITLE
docs: add Arch-based (AUR) install command to Linux installation page

### DIFF
--- a/src/pypilinux.rst
+++ b/src/pypilinux.rst
@@ -11,6 +11,7 @@ Install Python
   
   * Ubuntu/Debian: ``sudo apt install python3 python3-pip``
   * Centos/Redhat: ``sudo yum install python3 python3-pip``
+  * Arch Linux/Manjaro:  ``yay -S python-openseespy``
 
 
 Install in terminal


### PR DESCRIPTION
Hi Dr. Zhu,

Following up on the PR I submitted to the main OpenSeesPy repository:

I am the maintainer of the `python-openseespy` package on the Arch User Repository (AUR). Due to the PEP 668 `externally-managed-environment` restrictions on modern Arch-based Linux distributions, users can no longer use global `pip` installs directly.

To help users bypass this, this PR adds the corresponding AUR helper command to the PyPI (Linux) documentation page. Since the AUR package handles all dependencies and installs the library system-wide seamlessly, Arch-based users can skip the terminal pip steps entirely.

Thank you for your excellent work on OpenSeesPy!