### PR TITLE
docs: add six constraint query commands (getFixedNodes, getConstrainedNodes, etc.)

### DIFF
--- a/src/getConstrainedDOFs.rst
+++ b/src/getConstrainedDOFs.rst
@@ -1,0 +1,30 @@
+.. include:: sub.txt
+
+=====================
+ getConstrainedDOFs command
+=====================
+
+.. function:: getConstrainedDOFs(nodeTag)
+
+   Returns the constrained (slave) DOF numbers for a multi-point constraint.
+
+   The command retrieves the DOF numbers on the slave node that are constrained
+   by a master node.
+
+**Arguments**
+
+   ========================   ===========================================================================
+   ``nodeTag`` |int|          **Constrained (slave) node** tag to query.
+   ========================   ===========================================================================
+
+**Return Value**
+
+   A list of integers containing the constrained DOF numbers (1-based) on the slave node.
+   Returns an empty list ``[]`` if the node is not a slave node or has no constraints.
+
+**Notes**
+
+   - DOF numbers are 1-based (1, 2, 3 correspond to X, Y, Z translations in 2D).
+   - This command requires a **slave node** as input.
+
+

--- a/src/getConstrainedNodes.rst
+++ b/src/getConstrainedNodes.rst
@@ -1,0 +1,27 @@
+.. include:: sub.txt
+
+=====================
+ getConstrainedNodes command
+=====================
+
+.. function:: getConstrainedNodes()
+
+   Returns all constrained (slave) node tags for multi-point constraints in the domain.
+
+   The command retrieves all slave nodes associated with multi-point constraints (MP_Constraint)
+   in the domain.
+
+**Arguments**
+
+   None.
+
+**Return Value**
+
+   Returns a list of all constrained (slave) node tags (e.g., ``[2, 5, 7]``) in the domain.
+   Returns an empty list ``[]`` if no multi-point constraints exist.
+
+**Notes**
+
+   - This command does not accept any arguments. Calling with a node tag (e.g., ``getConstrainedNodes(2)``) returns an empty list.
+   - To find the master node for a specific slave node, use ``getRetainedNodes(slaveNodeTag)``.
+

--- a/src/getFixedDOFs.rst
+++ b/src/getFixedDOFs.rst
@@ -1,0 +1,24 @@
+.. include:: sub.txt
+
+=====================
+ getFixedDOFs command
+=====================
+
+.. function:: getFixedDOFs(nodeTag)
+
+Returns a list of fixed DOF numbers for a specified node.
+
+   The command retrieves all single-point constraints (SP_Constraint) applied to the given node
+   and returns the DOF numbers that are fixed.
+
+**Arguments**
+
+   ========================   ===========================================================================
+   ``nodeTag`` |int|          Node tag to query.
+   ========================   ===========================================================================
+
+**Return Value**
+
+   A list of integers containing the fixed DOF numbers (1-based) for the specified node.
+   Returns an empty list if the node has no fixed DOFs or the node does not exist.
+

--- a/src/getFixedNodes.rst
+++ b/src/getFixedNodes.rst
@@ -1,0 +1,17 @@
+.. include:: sub.txt
+
+=====================
+ getFixedNodes command
+=====================
+
+.. function:: getFixedNodes()
+
+   Returns a list of node tags that are fixed (via the ``fix`` command) in the domain.
+
+   The command iterates over all single-point constraints (SP_Constraint) in the domain,
+   extracts the node tags, sorts them, and removes duplicates.
+
+   **Return Value**
+
+   A list of integers containing the tags of nodes that have at least one fixed DOF.
+   Returns an empty list if no fixed nodes are found.

--- a/src/getRetainedDOFs.rst
+++ b/src/getRetainedDOFs.rst
@@ -1,0 +1,24 @@
+.. include:: sub.txt
+
+=====================
+ getRetainedDOFs command
+=====================
+
+.. function:: getRetainedDOFs(nodeTag)
+
+   Returns the retained (master) DOF numbers for a multi-point constraint.
+
+   The command retrieves the DOF numbers on the master node that participate in
+   the constraint.
+
+**Arguments**
+
+   ========================   ===========================================================================
+   ``nodeTag`` |int|          **Master (retained) node** tag to query.
+   ========================   ===========================================================================
+
+**Return Value**
+
+   A list of integers containing the retained DOF numbers (1-based) on the master node.
+   Returns an empty list if the node is not a master node or has no constraints.
+

--- a/src/getRetainedNodes.rst
+++ b/src/getRetainedNodes.rst
@@ -1,0 +1,31 @@
+.. include:: sub.txt
+
+=====================
+ getRetainedNodes command
+=====================
+
+.. function:: getRetainedNodes(nodeTag=None)
+
+   Returns the master (retained) node tag(s) for multi-point constraints.
+
+   The command retrieves master nodes associated with multi-point constraints (MP_Constraint)
+   in the domain.
+
+**Arguments**
+
+   ========================   ===========================================================================
+   ``nodeTag`` |int|          Optional. Constrained (slave) node tag to query.
+                             If provided, returns the master node that constrains this slave node.
+                             If omitted, returns all master nodes in the domain.
+   ========================   ===========================================================================
+
+**Return Value**
+
+   - If called without arguments: Returns a list of all master (retained) node tags in the domain.
+   - If called with a node tag: Returns a list containing the master node tag (e.g., ``[1]``) if the specified node is a constrained (slave) node. Returns an empty list ``[]`` if the node is not a constrained node.
+
+**Notes**
+
+   - The input `nodeTag` must be a **constrained (slave) node**. If a master node is provided, the command returns an empty list without an error message.
+   - This command does not provide reverse lookup (i.e., finding all slave nodes constrained by a master node).
+

--- a/src/outputcmds.rst
+++ b/src/outputcmds.rst
@@ -16,9 +16,15 @@ Get outputs from OpenSees. These commands don't change internal states of OpenSe
 #. :doc:`eleForce`
 #. :doc:`eleNodes`
 #. :doc:`eleResponse`
+#. :doc:`getConstrainedDOFs`
+#. :doc:`getConstrainedNodes`
 #. :doc:`getEleTags`
+#. :doc:`getFixedDOFs`
+#. :doc:`getFixedNodes`
 #. :doc:`getLoadFactor`
 #. :doc:`getNodeTags`
+#. :doc:`getRetainedDOFs`
+#. :doc:`getRetainedNodes`
 #. :doc:`getTime`
 #. :doc:`nodeAccel`
 #. :doc:`nodeBounds`


### PR DESCRIPTION
### Description
This PR adds documentation for six constraint query commands that are currently undocumented in OpenSeesPyDoc.

### Commands added
- `getFixedNodes` - returns all fixed nodes
- `getFixedDOFs` - returns fixed DOFs for a node
- `getConstrainedNodes` - returns all constrained (slave) nodes
- `getRetainedNodes` - returns all retained (master) nodes
- `getConstrainedDOFs` - returns constrained DOFs for a slave node
- `getRetainedDOFs` - returns retained DOFs for a master node

### Testing
- Each command tested locally with OpenSeesPy
- Documentation built successfully with `sphinx-build`

### Notes
As encouraged in the documentation:  
> "You are very welcome to contribute to OpenSeesPy with new command documents..."

The `equationConstraint` command will be added in a follow-up PR.